### PR TITLE
Write output to `rootDir`

### DIFF
--- a/src/Servant/TypeScript.hs
+++ b/src/Servant/TypeScript.hs
@@ -91,8 +91,8 @@ writeTypeScriptLibrary = writeTypeScriptLibrary' defaultServantTypeScriptOptions
 -- | Write the TypeScript client library for the given API to the given folder.
 writeTypeScriptLibrary' :: forall api. MainConstraints api => ServantTypeScriptOptions -> Proxy api -> FilePath -> IO ()
 writeTypeScriptLibrary' opts _ rootDir = flip runReaderT opts $ do
-  writeClientTypes (Proxy @api) "/tmp/test"
-  writeClientLibraries (Proxy @api) "/tmp/test"
+  writeClientTypes (Proxy @api) rootDir
+  writeClientLibraries (Proxy @api) rootDir
 
 writeClientTypes :: forall api. (
   HasForeign LangTSDecls [TSDeclaration] api


### PR DESCRIPTION
When I run my application, it writes to `/tmp/test/`:

```bash
λ file /tmp/test/client.ts
/tmp/test/client.ts: cannot open '/tmp/test/client.ts' (No such file or directory)
λ file /tmp/test/client.d.ts
/tmp/test/client.d.ts: cannot open '/tmp/test/client.d.ts' (No such file or directory)
λ
λ stack run tsdef
λ
λ file /tmp/test/client.ts
/tmp/test/client.ts: Java source, ASCII text
λ file /tmp/test/client.d.ts
/tmp/test/client.d.ts: ASCII text
λ
```

The `rootDir` variable isn't referenced, and [the documentation](https://hackage.haskell.org/package/servant-typescript-0.1.0.1/docs/Servant-TypeScript.html) suggests that it'll write to the supplied folder, so I suspect `rootDir` is probably what was intended here. Thanks for reviewing/considering this PR!